### PR TITLE
Fix method removed in Ruby 3.2

### DIFF
--- a/lib/i18n_screwdriver.rb
+++ b/lib/i18n_screwdriver.rb
@@ -24,7 +24,7 @@ module I18nScrewdriver
   end
 
   def self.file_with_translations_exists?(locale)
-    File.exists?(filename_for_locale(locale))
+    File.exist?(filename_for_locale(locale))
   end
 
   def self.load_translations(locale)

--- a/lib/i18n_screwdriver.rb
+++ b/lib/i18n_screwdriver.rb
@@ -29,7 +29,7 @@ module I18nScrewdriver
 
   def self.load_translations(locale)
     path = filename_for_locale(locale)
-    raise Error, "File #{path} not found!" unless File.exists?(path)
+    raise Error, "File #{path} not found!" unless File.exist?(path)
     sanitize_hash(YAML.load_file(path)[locale])
   end
 


### PR DESCRIPTION
Fix the call to `File.exists?` which was deprecated in Ruby 2.2 and removed in Ruby 3.2.